### PR TITLE
use relative instead of absolute height

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,7 +25,7 @@ useHead({
 
 <style>
 .height {
-  height: 100vh;
+  height: 100%;
 }
 
 .text {


### PR DESCRIPTION
The index page uses an absolute height of 100vh. As the navbar also takes some space
this results in an overflow as shown in the picture:

![image](https://github.com/akumarujon/website/assets/74106482/32628622-bba7-48a4-9c2b-491269e56444)

If not indended, use the relative height to remove the overflow